### PR TITLE
Close conn when force=true, unused error, lint fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,10 +55,8 @@ func (c *Client) getStream() (Stream, error) {
 			return Stream{}, err
 		}
 		return conn.Stream()
-	} else {
-		return stream, err
 	}
-
+	return stream, err
 }
 
 func (c *Client) getConn(force bool) (*Conn, error) {
@@ -66,6 +64,9 @@ func (c *Client) getConn(force bool) (*Conn, error) {
 		conn, err := Dial(c.Network, c.Address)
 		if err != nil {
 			return nil, err
+		}
+		if c.conn != nil {
+			c.conn.Close()
 		}
 		go conn.Listen()
 		c.conn = &conn

--- a/counter.go
+++ b/counter.go
@@ -21,7 +21,7 @@ func (c *Counter) Get() (uint32, error) {
 	defer c.Unlock()
 	current := c.current
 	if c.current+2 > MAX_STREAM_ID {
-		return 0, nil
+		return 0, ExceedError
 	}
 	c.current += 2
 	return current, nil


### PR DESCRIPTION
When you call `getConn(true)`, the current conn may become zombie?


Do you mind if I created PR? If currently you aren't welcome to contribute, please close this:bow:

P.S. I come from your blog!